### PR TITLE
Adjust CSS to minimise overlap of ruler & controls

### DIFF
--- a/PhysicalRuler/physicalRuler.js
+++ b/PhysicalRuler/physicalRuler.js
@@ -412,7 +412,7 @@
       options.pixelsPerMillimeter = 1 / (millimetersPerPhysicalUnit[service.physicalUnits] * service.physicalScale);
       jQuery.extend(true, this.osd, {
         documentRulerConfig: options
-      });
+      }); 
       this.osd.documentRuler(this.osd.documentRulerConfig);
       this.osd.rulerInstance.refresh();
       this.osd.rulerInstance.updateSize();


### PR DESCRIPTION
Ruler and workspace controls can overlap and become obscure, so there are dynamic CSS changes to reposition controls and the bottom panel to minimise the overlap